### PR TITLE
Added vanishOnJoin configuration option

### DIFF
--- a/src/config.yml
+++ b/src/config.yml
@@ -6,6 +6,7 @@ hooks:
     essentials: false
     dynmap: false
     JSONAPI: false
+vanishOnJoin: true
 enableColoration: false
 spoutcraft:
     enable: false

--- a/src/to/joe/vanish/VanishPlugin.java
+++ b/src/to/joe/vanish/VanishPlugin.java
@@ -88,12 +88,20 @@ public class VanishPlugin extends JavaPlugin {
     private Logger log;
 
     private boolean enableColoration;
+    private boolean vanishOnJoin;
 
     /**
      * @return whether or not the hacky packet user coloration is enabled
      */
     public boolean colorationEnabled() {
         return this.enableColoration;
+    }
+
+    /**
+     * @return whether or not to vanish players on join
+     */
+    public boolean joinVanished() {
+        return this.vanishOnJoin;
     }
 
     /**
@@ -214,6 +222,7 @@ public class VanishPlugin extends JavaPlugin {
         config.options().copyDefaults(true);
 
         this.enableColoration = config.getBoolean("enableColoration", false);
+        this.vanishOnJoin     = config.getBoolean("vanishOnJoin", true);
 
         this.essentialsHook.onPluginEnable(config.getBoolean("hooks.essentials", false));
 

--- a/src/to/joe/vanish/listeners/ListenPlayerJoinEarly.java
+++ b/src/to/joe/vanish/listeners/ListenPlayerJoinEarly.java
@@ -16,7 +16,8 @@ public class ListenPlayerJoinEarly extends PlayerListener {
 
     @Override
     public void onPlayerJoin(PlayerJoinEvent event) {
-        if (VanishPerms.silentJoin(event.getPlayer())) {
+        if (this.plugin.joinVanished() &&
+                VanishPerms.silentJoin(event.getPlayer())) {
             this.plugin.getManager().toggleVanishQuiet(event.getPlayer());
             this.plugin.hooksVanish(event.getPlayer());
         }

--- a/src/to/joe/vanish/listeners/ListenPlayerJoinLate.java
+++ b/src/to/joe/vanish/listeners/ListenPlayerJoinLate.java
@@ -17,7 +17,8 @@ public class ListenPlayerJoinLate extends PlayerListener {
 
     @Override
     public void onPlayerJoin(PlayerJoinEvent event) {
-        if (VanishPerms.silentJoin(event.getPlayer())) {
+        if (this.plugin.joinVanished() &&
+                VanishPerms.silentJoin(event.getPlayer())) {
             this.plugin.getManager().getAnnounceManipulator().addToDelayedAnnounce(event.getPlayer().getName());
             event.setJoinMessage(null);
             String add = "";


### PR DESCRIPTION
I have added a vanishOnJoin configuration option to the plugin to allow for the disabling of a player being vanish on join.  I've been meaning to do this for sometime, and as another server administrator asked if this was possible, I figured I'd just implement it quickly.
