### PR TITLE
VanishAnnounceManipulator was all broken.

### DIFF
--- a/src/org/kitteh/vanish/VanishAnnounceManipulator.java
+++ b/src/org/kitteh/vanish/VanishAnnounceManipulator.java
@@ -57,7 +57,7 @@ public class VanishAnnounceManipulator {
      * @param player
      */
     public void fakeJoin(Player player) {
-        if (this.playerOnlineStatus.containsKey(player) && this.playerOnlineStatus.get(player)) {
+        if (this.playerOnlineStatus.containsKey(player.getName()) && this.playerOnlineStatus.get(player.getName())) {
             return;
         }
         this.plugin.getServer().broadcastMessage(ChatColor.YELLOW + this.injectPlayerInformation(Settings.fakeJoin(), player));
@@ -73,7 +73,7 @@ public class VanishAnnounceManipulator {
      * @param player
      */
     public void fakeQuit(Player player) {
-        if (this.playerOnlineStatus.containsKey(player) && !this.playerOnlineStatus.get(player.getName())) {
+        if (this.playerOnlineStatus.containsKey(player.getName()) && !this.playerOnlineStatus.get(player.getName())) {
             return;
         }
         this.plugin.getServer().broadcastMessage(ChatColor.YELLOW + this.injectPlayerInformation(Settings.fakeQuit(), player));
@@ -90,7 +90,7 @@ public class VanishAnnounceManipulator {
      * @param player
      */
     public void vanishToggled(Player player) {
-        if (!Settings.autoFakeJoinSilent() || !this.delayedAnnouncePlayerList.contains(player)) {
+        if (!Settings.autoFakeJoinSilent() || !this.delayedAnnouncePlayerList.contains(player.getName())) {
             return;
         }
         this.fakeJoin(player);


### PR DESCRIPTION
The VanishAnnounceManipulator had some list and hashmap objects which stored the names of players as strings. However, a couple methods tried to store or retrieve a Player object from these, which was transformed into a string that wasn't exactly equal to their username.

An easily way to demonstrate the brokenness is to type "/v fakejoin" twice. The player shouldn't be able to get repeated join messages to be broadcast. This commit fixes that.
