### PR TITLE
Fixes for sometimes showing invisible people to others

### DIFF
--- a/src/org/kitteh/vanish/VanishManager.java
+++ b/src/org/kitteh/vanish/VanishManager.java
@@ -197,7 +197,7 @@ public class VanishManager {
             if (vanishing && !VanishPerms.canSeeAll(otherPlayer) && otherPlayer.canSee(vanishingPlayer)) {
                 Debuggle.log("Hiding "+vanishingPlayer.getName()+" from "+otherPlayer.getName());
                 otherPlayer.hidePlayer(vanishingPlayer);
-            } else if (!otherPlayer.canSee(vanishingPlayer)) {
+            } else if ((!vanishing || VanishPerms.canSeeAll(otherPlayer)) && !otherPlayer.canSee(vanishingPlayer)) {
                 Debuggle.log("Showing "+vanishingPlayer.getName()+" to "+otherPlayer.getName());
                 otherPlayer.showPlayer(vanishingPlayer);
             }


### PR DESCRIPTION
A recent fix in CraftBukkit made it so that a player now persists what players they were hidden from even after reconnecting. This broke some of the faulty logic in VanishNoPacket which happened to work as long as players were visible to all when first connecting.

In VanishNoPacket currently without this fix, if you disconnect while invisible, and then reconnect with the joinvanished permission, you'll be told that you're invisible but you won't be. The last commit here fixes some faulty logic which led to this. The other commits do small non-critical tweaks.
