### PR TITLE
Set who a player can see as soon as they join.

### DIFF
--- a/src/org/kitteh/vanish/listeners/ListenPlayerJoin.java
+++ b/src/org/kitteh/vanish/listeners/ListenPlayerJoin.java
@@ -17,8 +17,11 @@ public class ListenPlayerJoin implements Listener {
         this.plugin = instance;
     }
 
+    // Handle setting who the player can see and setting invisibility
+    // if needed here.
     @EventHandler(priority = EventPriority.LOW)
     public void onPlayerJoinEarly(PlayerJoinEvent event) {
+        this.plugin.getManager().resetSeeing(event.getPlayer());
         if (VanishPerms.joinVanished(event.getPlayer())) {
             this.plugin.getManager().toggleVanishQuiet(event.getPlayer());
             this.plugin.hooksVanish(event.getPlayer());
@@ -26,6 +29,7 @@ public class ListenPlayerJoin implements Listener {
         this.plugin.hooksJoin(event.getPlayer());
     }
 
+    // Handle any messages to the player here
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onPlayerJoinLate(PlayerJoinEvent event) {
         if (VanishPerms.joinVanished(event.getPlayer())) {
@@ -45,6 +49,5 @@ public class ListenPlayerJoin implements Listener {
             event.getPlayer().sendMessage(ChatColor.AQUA + "[Vanish] This is version " + ChatColor.DARK_AQUA + this.plugin.getCurrentVersion() + ChatColor.AQUA + ", latest is " + ChatColor.DARK_AQUA + this.plugin.getLatestKnownVersion());
             event.getPlayer().sendMessage(ChatColor.AQUA + "[Vanish] Check " + ChatColor.DARK_AQUA + "http://dev.bukkit.org/server-mods/vanish/");
         }
-        this.plugin.getManager().resetSeeing(event.getPlayer());
     }
 }


### PR DESCRIPTION
ListenPlayerJoin.java catches the player join event twice, one hook being at low priority and one at high priority. The low priority one runs first on player join and sets whether the player is invisible, and then runs plugin hooks. The high priority one runs last, displays some messages to the player if necessary, and then sets what other players the new player can see.

This commit moves setting what other players the new player can see to the low priority hook, so it runs early, before many other plugins process the join event. (Main case is for a plugin that shows who is online when a player joins (and follows the Bukkit Vanish API); we want to have invisible players hidden from the new player before the new player is shown a list of players.) This also has the benefit of providing a clear distinction between the purposes of the low priority and high priority hooks. The high priority hook is solely for showing messages to the new player now.
