### PR TITLE
Added check for Settings.getEnableJoinVanished() in player join event handler

### DIFF
--- a/src/org/kitteh/vanish/Settings.java
+++ b/src/org/kitteh/vanish/Settings.java
@@ -16,6 +16,7 @@ public class Settings {
     private static String fakeJoin;
     private static boolean autoFakeJoinSilent;
     private static boolean worldChangeCheck;
+    private static boolean enableJoinVanished;
 
     /**
      * Tracking the config. Don't touch this.
@@ -73,10 +74,11 @@ public class Settings {
             plugin.saveConfig();
         }
         Settings.enablePermTest = config.getBoolean("permtest", false);
-        Settings.fakeJoin = config.getString("fakeannounce.join", "%p joined the game.").replace("&&", "§");
-        Settings.fakeQuit = config.getString("fakeannounce.quit", "%p left the game.").replace("&&", "§");
+        Settings.fakeJoin = config.getString("fakeannounce.join", "%p joined the game.").replace("&&", "ï¿½");
+        Settings.fakeQuit = config.getString("fakeannounce.quit", "%p left the game.").replace("&&", "ï¿½");
         Settings.autoFakeJoinSilent = config.getBoolean("fakeannounce.automaticforsilentjoin", false);
         Settings.worldChangeCheck = config.getBoolean("permissionsupdates.checkonworldchange", false);
+        Settings.enableJoinVanished = config.getBoolean("enablejoinvanished", false);
         if (config.getBoolean("debug", false)) {
             Debuggle.itsGoTime();
         } else {
@@ -102,5 +104,9 @@ public class Settings {
 
     public static boolean getWorldChangeCheck() {
         return Settings.worldChangeCheck;
+    }
+    
+    public static boolean getEnableJoinVanished() {
+        return Settings.enableJoinVanished;
     }
 }

--- a/src/org/kitteh/vanish/listeners/ListenPlayerJoin.java
+++ b/src/org/kitteh/vanish/listeners/ListenPlayerJoin.java
@@ -11,6 +11,8 @@ import org.kitteh.vanish.VanishCheck;
 import org.kitteh.vanish.VanishPerms;
 import org.kitteh.vanish.VanishPlugin;
 import org.kitteh.vanish.metrics.MetricsOverlord;
+import org.kitteh.vanish.Settings;
+
 
 public class ListenPlayerJoin implements Listener {
 
@@ -30,7 +32,7 @@ public class ListenPlayerJoin implements Listener {
     public void onPlayerJoinEarly(PlayerJoinEvent event) {
         event.getPlayer().setMetadata("vanished", new LazyMetadataValue(this.plugin, CacheStrategy.NEVER_CACHE, new VanishCheck(this.plugin.getManager(), event.getPlayer().getName())));
         this.plugin.getManager().resetSeeing(event.getPlayer());
-        if (VanishPerms.joinVanished(event.getPlayer())) {
+        if (Settings.getEnableJoinVanished() && VanishPerms.joinVanished(event.getPlayer())) {
             MetricsOverlord.joininvis.increment();
             this.plugin.getManager().toggleVanishQuiet(event.getPlayer());
             this.plugin.hooksVanish(event.getPlayer());
@@ -45,7 +47,7 @@ public class ListenPlayerJoin implements Listener {
      */
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onPlayerJoinLate(PlayerJoinEvent event) {
-        if (VanishPerms.joinVanished(event.getPlayer())) {
+        if (Settings.getEnableJoinVanished() && VanishPerms.joinVanished(event.getPlayer())) {
             String add = "";
             if (VanishPerms.canVanish(event.getPlayer())) {
                 add = " To appear: /vanish";


### PR DESCRIPTION
In case you want to permanently disable this without using permissions.  In our case Admins have a \* permission node but we don't want to join vanished so in the interest of keeping the permissions nodes clean I thought this would be a suitable change.
