### PR TITLE
Added ability to force a fake quit

### DIFF
--- a/src/org/kitteh/vanish/VanishAnnounceManipulator.java
+++ b/src/org/kitteh/vanish/VanishAnnounceManipulator.java
@@ -65,6 +65,19 @@ public class VanishAnnounceManipulator {
         MetricsOverlord.fakejoin.increment();
         this.playerOnlineStatus.put(player.getName(), true);
     }
+    
+    /**
+     * Call a forced fake quit for the player.
+     * Fires regardless of wether the server previously said they were online
+     * 
+     * @param player
+     */
+    public void forceFakeQuit(Player player){
+        this.plugin.getServer().broadcastMessage(ChatColor.YELLOW + this.injectPlayerInformation(Settings.getFakeQuit(), player));
+        this.plugin.log(player.getName() + " faked quitting");
+        MetricsOverlord.fakequit.increment();
+        this.playerOnlineStatus.put(player.getName(), false);
+    }
 
     /**
      * Call a fake quit for the player.

--- a/src/org/kitteh/vanish/VanishCommand.java
+++ b/src/org/kitteh/vanish/VanishCommand.java
@@ -103,12 +103,16 @@ public class VanishCommand implements CommandExecutor {
                     this.toggle(player, args[1]);
                 }
             } else if ((args[0].equalsIgnoreCase("fakequit") || args[0].equalsIgnoreCase("fq")) && VanishPerms.canFakeAnnounce(player)) {
-                if (!this.plugin.getManager().isVanished(player)) {
-                    this.plugin.getManager().toggleVanish(player);
+                if (args.length == 2 && (args[1].equalsIgnoreCase("force") || args[1].equalsIgnoreCase("f"))){
+                    this.plugin.getManager().getAnnounceManipulator().forceFakeQuit(player);
                 } else {
-                    player.sendMessage(ChatColor.RED + "Already invisible :)");
+                    if (!this.plugin.getManager().isVanished(player)) {
+                        this.plugin.getManager().toggleVanish(player);
+                    } else {
+                        player.sendMessage(ChatColor.RED + "Already invisible :)");
+                    }
+                    this.plugin.getManager().getAnnounceManipulator().fakeQuit(player);
                 }
-                this.plugin.getManager().getAnnounceManipulator().fakeQuit(player);
             } else if ((args[0].equalsIgnoreCase("fakejoin") || args[0].equalsIgnoreCase("fj")) && VanishPerms.canFakeAnnounce(player)) {
                 if (this.plugin.getManager().isVanished(player)) {
                     this.plugin.getManager().toggleVanish(player);


### PR DESCRIPTION
For: https://github.com/mbax/VanishNoPacket/issues/98

If you do /v fq f or /v fq force or any combination with the appropriate aliases, the server disregards if it showed you quitting before and sends out another broadcast claiming that you have quit.
