### PR TITLE
Added check for vehicle collision and cancel if the entity is an invisible player

### DIFF
--- a/src/org/kitteh/vanish/listeners/ListenEntity.java
+++ b/src/org/kitteh/vanish/listeners/ListenEntity.java
@@ -7,6 +7,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityTargetEvent;
+import org.bukkit.event.vehicle.VehicleEntityCollisionEvent;
 import org.kitteh.vanish.VanishPerms;
 import org.kitteh.vanish.VanishPlugin;
 
@@ -45,5 +46,12 @@ public class ListenEntity implements Listener {
             event.setCancelled(true);
         }
     }
+
+	@EventHandler
+	public void onVehicleEntityCollision(VehicleEntityCollisionEvent event) {
+		if ((event.getEntity() instanceof Player) && this.plugin.getManager().isVanished((Player) event.getEntity())) {
+            event.setCancelled(true);
+        }
+	}
 
 }


### PR DESCRIPTION
In response to [this issue](https://github.com/mbax/VanishNoPacket/issues/142).
