### PR TITLE
Compatibility with GriefPrevention

### DIFF
--- a/src/org/kitteh/vanish/listeners/ListenPlayerJoin.java
+++ b/src/org/kitteh/vanish/listeners/ListenPlayerJoin.java
@@ -43,7 +43,7 @@ public class ListenPlayerJoin implements Listener {
      * 
      * @param event
      */
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGH)
     public void onPlayerJoinLate(PlayerJoinEvent event) {
         StringBuilder statusUpdate = new StringBuilder();
         if (VanishPerms.joinVanished(event.getPlayer())) {


### PR DESCRIPTION
Basically, bigscary has told me that the priority of the login listener has to be HIGH instead of HIGHEST to ensure compatibility with GriefPrevention's login delay feature. I didn't thoroughly review the source code, but I don't believe that changing this will break anything, so I would ask that you please accept this pull request.
