### PR TITLE
Updated pom for 1.6. Project won't actually compile for 1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,8 +136,8 @@
         <version>2.3.2</version>
         <inherited>true</inherited>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
The project won't compile under Java 1.5, so I updated Maven to compile with 1.6. I'm not sure what you've been using to compile, but it isn't Java 1.5.
