### PR TITLE
Ignore cancelled events for events that can be cancelled

### DIFF
--- a/src/org/kitteh/vanish/listeners/ListenEntity.java
+++ b/src/org/kitteh/vanish/listeners/ListenEntity.java
@@ -19,7 +19,7 @@ public class ListenEntity implements Listener {
         this.plugin = instance;
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onEntityDamage(EntityDamageEvent event) {
         final Entity smacked = event.getEntity();
         if (smacked instanceof Player) {
@@ -40,14 +40,14 @@ public class ListenEntity implements Listener {
         }
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onEntityTarget(EntityTargetEvent event) {
         if ((event.getTarget() instanceof Player) && this.plugin.getManager().isVanished((Player) event.getTarget()) && VanishPerms.canNotFollow((Player) event.getTarget())) {
             event.setCancelled(true);
         }
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onVehicleEntityCollision(VehicleEntityCollisionEvent event) {
         if ((event.getEntity() instanceof Player) && this.plugin.getManager().isVanished((Player) event.getEntity())) {
             event.setCancelled(true);

--- a/src/org/kitteh/vanish/listeners/ListenInventory.java
+++ b/src/org/kitteh/vanish/listeners/ListenInventory.java
@@ -14,14 +14,14 @@ public class ListenInventory implements Listener {
         this.plugin = instance;
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onInventoryClick(InventoryClickEvent event) {
         if (this.plugin.chestFakeInUse(event.getWhoClicked().getName())) {
             event.setCancelled(true);
         }
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onInventoryClose(InventoryCloseEvent event) {
         if (this.plugin.chestFakeInUse(event.getPlayer().getName())) {
             this.plugin.chestFakeClose(event.getPlayer().getName());

--- a/src/org/kitteh/vanish/listeners/ListenPlayerMessages.java
+++ b/src/org/kitteh/vanish/listeners/ListenPlayerMessages.java
@@ -19,14 +19,14 @@ public class ListenPlayerMessages implements Listener {
         this.plugin = instance;
     }
 
-    @EventHandler(priority = EventPriority.LOWEST)
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerChat(PlayerChatEvent event) {
         if (this.plugin.getManager().isVanished(event.getPlayer()) && VanishPerms.canNotChat(event.getPlayer())) {
             event.setCancelled(true);
         }
     }
 
-    @EventHandler(priority = EventPriority.LOWEST)
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerCommandPreprocess(PlayerCommandPreprocessEvent event) {
         if (event.getMessage().toLowerCase().startsWith("/me ") && this.plugin.getManager().isVanished(event.getPlayer()) && VanishPerms.canNotChat(event.getPlayer())) {
             event.setCancelled(true);

--- a/src/org/kitteh/vanish/listeners/ListenPlayerOther.java
+++ b/src/org/kitteh/vanish/listeners/ListenPlayerOther.java
@@ -29,21 +29,21 @@ public class ListenPlayerOther implements Listener {
         this.plugin = instance;
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onBucketFill(PlayerBucketFillEvent event) {
         if (this.plugin.getManager().isVanished(event.getPlayer()) && VanishPerms.canNotInteract(event.getPlayer())) {
             event.setCancelled(true);
         }
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onDrop(PlayerDropItemEvent event) {
         if (this.plugin.getManager().isVanished(event.getPlayer()) && VanishPerms.canNotInteract(event.getPlayer())) {
             event.setCancelled(true);
         }
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onFoodChange(FoodLevelChangeEvent event) {
         if (event.getEntity() instanceof Player) {
             final Player player = (Player) event.getEntity();
@@ -53,7 +53,7 @@ public class ListenPlayerOther implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPlayerInteract(PlayerInteractEvent event) {
         if ((event.getAction() == Action.RIGHT_CLICK_BLOCK) && (event.getClickedBlock().getType() == Material.CHEST)) {
             if (this.plugin.getManager().isVanished(event.getPlayer()) && VanishPerms.canReadChestsSilently(event.getPlayer())) {
@@ -78,7 +78,7 @@ public class ListenPlayerOther implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPlayerPickupItem(PlayerPickupItemEvent event) {
         if (this.plugin.getManager().isVanished(event.getPlayer()) && VanishPerms.canNotPickUp(event.getPlayer())) {
             event.setCancelled(true);
@@ -101,7 +101,7 @@ public class ListenPlayerOther implements Listener {
         this.plugin.chestFakeClose(event.getPlayer().getName());
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onShear(PlayerShearEntityEvent event) {
         if (this.plugin.getManager().isVanished(event.getPlayer()) && VanishPerms.canNotInteract(event.getPlayer())) {
             event.setCancelled(true);

--- a/src/org/kitteh/vanish/listeners/ListenToYourHeart.java
+++ b/src/org/kitteh/vanish/listeners/ListenToYourHeart.java
@@ -17,7 +17,7 @@ public class ListenToYourHeart implements Listener {
         this.plugin = plugin;
     }
 
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void badReview(PaintingBreakEvent criticism) {
         if (criticism instanceof PaintingBreakByEntityEvent) {
             final Entity critic = ((PaintingBreakByEntityEvent) criticism).getRemover();


### PR DESCRIPTION
The main intention of ignoring cancelling events is the new feature that allows Vanish to automatically open chests while you are vanished. This has repercussions if for example the server is using LWC. If the player really CANNOT access this chest, the event WILL be cancelled but Vanish will still let them inside this chest they should not be able to access.
