### PR TITLE
Remove Vanish metadata on disable

### DIFF
--- a/src/org/kitteh/vanish/VanishPlugin.java
+++ b/src/org/kitteh/vanish/VanishPlugin.java
@@ -223,6 +223,7 @@ public class VanishPlugin extends JavaPlugin {
         for (final Player player : VanishPlugin.this.getServer().getOnlinePlayers()) {
             if (player != null) {
                 if (this.manager.isVanished(player)) {
+                    player.removeMetadata("vanished", this);
                     ((CraftPlayer) player).getHandle().netServerHandler.sendPacket(new Packet42RemoveMobEffect(((CraftPlayer) player).getEntityId(), new MobEffect(MobEffectList.INVISIBILITY.getId(), 0, 0)));
                     player.sendMessage(ChatColor.DARK_AQUA + "[Vanish] You have been forced visible by a reload.");
                 }


### PR DESCRIPTION
I don't like the idea of CraftBukkit holding a reference to the old VNP plugin object. 
_If you check the metadata while VNP is disabled it still returns the old value. VNP needs to sever its references._

Feel free to disregard if I have misunderstood this issue.

Besides, it's **invalid** if the plugin is disabled - and I have disabled plugins individually in the past and will do so in the future.
