### PR TITLE
Update messaging channel name to comply with Minecraft 1.13 requirements

### DIFF
--- a/src/main/java/org/kitteh/vanish/VanishManager.java
+++ b/src/main/java/org/kitteh/vanish/VanishManager.java
@@ -1,4 +1,4 @@
-  package org.kitteh.vanish;
+package org.kitteh.vanish;
 
 import com.google.common.collect.ImmutableSet;
 import org.bukkit.ChatColor;

--- a/src/main/java/org/kitteh/vanish/VanishManager.java
+++ b/src/main/java/org/kitteh/vanish/VanishManager.java
@@ -1,4 +1,4 @@
-package org.kitteh.vanish;
+  package org.kitteh.vanish;
 
 import com.google.common.collect.ImmutableSet;
 import org.bukkit.ChatColor;
@@ -76,15 +76,15 @@ public final class VanishManager {
         this.announceManipulator = new VanishAnnounceManipulator(this.plugin);
         this.plugin.getServer().getScheduler().scheduleSyncRepeatingTask(this.plugin, this.showPlayer, 4, 4);
 
-        this.plugin.getServer().getMessenger().registerIncomingPluginChannel(this.plugin, "vanishStatus", new PluginMessageListener() {
+        this.plugin.getServer().getMessenger().registerIncomingPluginChannel(this.plugin, "vanish:status", new PluginMessageListener() {
             @Override
             public void onPluginMessageReceived(String channel, Player player, byte[] message) {
-                if (channel.equals("vanishStatus") && new String(message).equals("check")) {
-                    player.sendPluginMessage(plugin, "vanishStatus", VanishManager.this.isVanished(player) ? new byte[]{0x01} : new byte[]{0x00});
+                if (channel.equals("vanish:status") && new String(message).equals("check")) {
+                    player.sendPluginMessage(plugin, "vanish:status", VanishManager.this.isVanished(player) ? new byte[]{0x01} : new byte[]{0x00});
                 }
             }
         });
-        this.plugin.getServer().getMessenger().registerOutgoingPluginChannel(this.plugin, "vanishStatus");
+        this.plugin.getServer().getMessenger().registerOutgoingPluginChannel(this.plugin, "vanish:status");
 
     }
 
@@ -278,7 +278,7 @@ public final class VanishManager {
             }
         }
         this.plugin.getServer().getPluginManager().callEvent(new VanishStatusChangeEvent(vanishingPlayer, vanishing));
-        vanishingPlayer.sendPluginMessage(this.plugin, "vanishStatus", vanishing ? new byte[]{0x01} : new byte[]{0x00});
+        vanishingPlayer.sendPluginMessage(this.plugin, "vanish:status", vanishing ? new byte[]{0x01} : new byte[]{0x00});
         final java.util.Collection<? extends Player> playerList = this.plugin.getServer().getOnlinePlayers();
         for (final Player otherPlayer : playerList) {
             if (vanishingPlayer.equals(otherPlayer)) {


### PR DESCRIPTION
Minecraft version 1.13 now requires plugin messaging channels to follow a colon separated (and lowercase) format.

This pull request just renames the plugin messaging channel "vanishStatus" to "vanish:status" in order to comply with this new requirement. This will prevent the error thrown on startup.

(I did try to compile this build to test with 1.13, unfortunately I kept getting Maven errors even though I thought it was all configured correctly)