### PR TITLE
Update to 1.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,8 @@
       <url>http://repo.kitteh.org/content/groups/public</url>
     </repository>
     <repository>
-      <id>bukkit-repo</id>
-      <url>http://repo.bukkit.org/content/groups/public</url>
+      <id>spigot-repo</id>
+      <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
     </repository>
   </repositories>
 
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>org.bukkit</groupId>
       <artifactId>bukkit</artifactId>
-      <version>1.7.10-R0.1-SNAPSHOT</version>
+      <version>1.13-R0.1-SNAPSHOT</version>
       <type>jar</type>
       <optional>true</optional>
     </dependency>

--- a/src/main/java/org/kitteh/vanish/hooks/plugins/EssentialsHook.java
+++ b/src/main/java/org/kitteh/vanish/hooks/plugins/EssentialsHook.java
@@ -7,7 +7,6 @@ import org.kitteh.vanish.hooks.Hook;
 
 import com.earth2me.essentials.IEssentials;
 
-@SuppressWarnings("deprecation")
 public final class EssentialsHook extends Hook {
     private final VanishPlugin plugin;
     private IEssentials essentials;

--- a/src/main/java/org/kitteh/vanish/hooks/plugins/SpoutCraftHook.java
+++ b/src/main/java/org/kitteh/vanish/hooks/plugins/SpoutCraftHook.java
@@ -2,7 +2,6 @@ package org.kitteh.vanish.hooks.plugins;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.logging.Level;
@@ -99,14 +98,14 @@ public final class SpoutCraftHook extends Hook implements Listener {
         final File confFile = new File(this.plugin.getDataFolder(), "spoutcraft.yml");
         final FileConfiguration config = YamlConfiguration.loadConfiguration(confFile);
         config.options().copyDefaults(true);
-        final InputStream stream = this.plugin.getResource("spoutcraft.yml");
-        if (stream == null) {
+        final File spoutcraft = new File(this.plugin.getDataFolder(), "spoutcraft.yml");
+        if (!spoutcraft.canRead()) {
             this.plugin.getLogger().info("Defaults for spoutcraft.yml not loaded");
             this.plugin.getLogger().info("The /reload command is not fully supported by this plugin or Spout");
             this.enabled = false;
             return;
         }
-        config.setDefaults(YamlConfiguration.loadConfiguration(stream));
+        config.setDefaults(YamlConfiguration.loadConfiguration(spoutcraft));
         try {
             config.save(confFile);
         } catch (final IOException e) {

--- a/src/main/java/org/kitteh/vanish/listeners/ListenPlayerOther.java
+++ b/src/main/java/org/kitteh/vanish/listeners/ListenPlayerOther.java
@@ -16,12 +16,12 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
+import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.entity.FoodLevelChangeEvent;
 import org.bukkit.event.player.PlayerBucketFillEvent;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
-import org.bukkit.event.player.PlayerPickupItemEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerShearEntityEvent;
 import org.bukkit.inventory.Inventory;
@@ -117,7 +117,7 @@ public final class ListenPlayerOther implements Listener {
             event.setCancelled(true);
             return;
         }
-        if ((event.getAction() == Action.PHYSICAL) && (event.getClickedBlock().getType() == Material.SOIL)) {
+        if ((event.getAction() == Action.PHYSICAL) && (event.getClickedBlock().getType() == Material.FARMLAND)) {
             if (this.plugin.getManager().isVanished(player) && VanishPerms.canNotTrample(player)) {
                 event.setCancelled(true);
             }
@@ -125,9 +125,12 @@ public final class ListenPlayerOther implements Listener {
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-    public void onPlayerPickupItem(PlayerPickupItemEvent event) {
-        if (this.plugin.getManager().isVanished(event.getPlayer()) && VanishPerms.canNotPickUp(event.getPlayer())) {
-            event.setCancelled(true);
+    public void onPlayerPickupItem(EntityPickupItemEvent event) {
+        if (event.getEntity() instanceof Player) {
+            Player player = (Player) event.getEntity();
+            if (this.plugin.getManager().isVanished(player) && VanishPerms.canNotPickUp(player)) {
+                event.setCancelled(true);
+            }
         }
     }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,7 @@
 name: VanishNoPacket
 main: org.kitteh.vanish.VanishPlugin
 version: '${vnp-version}'
+api-version: 1.13
 website: http://kitteh.org
 softdepend: [Essentials,dynmap,JSONAPI,bPermissions,Spout,GeoIPTools,TagAPI,ProtocolLib,Vault]
 author: mbaxter


### PR DESCRIPTION
This updates the plugin to be usable with Version 1.13:
 - Update repository list in POM to existing ones
 - Update bukkit version to 1.13
 - Change api version to 1.13
 - Update plugin channel name
 - Update naming of block
 - Use File instead of Stream for YamlConfiguration
 - Get rid of some deprecated stuff

Worked for me on a Spigot 1.13 server.