### PR TITLE
Add DiscordSRV Hook

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,10 @@
             <id>placeholderapi</id>
             <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
+        <repository>
+            <id>Scarsz-Nexus</id>
+            <url>https://nexus.scarsz.me/content/groups/public/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -95,6 +99,12 @@
             <artifactId>junit</artifactId>
             <version>4.13.1</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.discordsrv</groupId>
+            <artifactId>discordsrv</artifactId>
+            <version>1.21.1</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <packaging>jar</packaging>
 
     <name>VanishNoPacket</name>
-    <version>3.21.G0.1</version>
+    <version>3.22</version>
 
     <url>http://github.com/mbax/VanishNoPacket</url>
 

--- a/src/main/java/org/kitteh/vanish/Settings.java
+++ b/src/main/java/org/kitteh/vanish/Settings.java
@@ -29,7 +29,7 @@ public final class Settings {
     private static boolean worldChangeCheck;
     private static int lightningEffectCount;
 
-    private static final int confVersion = 7; // Tracking config version
+    private static final int confVersion = 8; // Tracking config version
 
     public static boolean getAutoFakeJoinSilent() {
         return Settings.autoFakeJoinSilent;
@@ -84,6 +84,9 @@ public final class Settings {
             }
             if (ver <= 6) {
                 config.set("hooks.dynmap", false);
+            }
+            if (ver <= 7) {
+                config.set("hooks.discordsrv", false);
             }
             config.set("configVersionDoNotTouch.SeriouslyThisWillEraseYourConfig", Settings.confVersion);
             plugin.saveConfig();

--- a/src/main/java/org/kitteh/vanish/VanishAnnounceManipulator.java
+++ b/src/main/java/org/kitteh/vanish/VanishAnnounceManipulator.java
@@ -108,6 +108,7 @@ public final class VanishAnnounceManipulator {
             this.plugin.getServer().broadcastMessage(ChatColor.YELLOW + this.injectPlayerInformation(Settings.getFakeJoin(), player));
             this.plugin.getLogger().info(player.getName() + " faked joining");
             this.playerOnlineStatus.put(player.getName(), true);
+            this.plugin.hooksFakeJoin(player);
         }
     }
 
@@ -116,6 +117,7 @@ public final class VanishAnnounceManipulator {
             this.plugin.getServer().broadcastMessage(ChatColor.YELLOW + this.injectPlayerInformation(Settings.getFakeQuit(), player));
             this.plugin.getLogger().info(player.getName() + " faked quitting");
             this.playerOnlineStatus.put(player.getName(), false);
+            this.plugin.hooksFakeQuit(player);
         }
     }
 

--- a/src/main/java/org/kitteh/vanish/VanishPlugin.java
+++ b/src/main/java/org/kitteh/vanish/VanishPlugin.java
@@ -252,6 +252,9 @@ public final class VanishPlugin extends JavaPlugin {
         if (this.getConfig().getBoolean("hooks.dynmap", false)) {
             this.hookManager.getHook(HookType.Dynmap).onEnable();
         }
+        if (this.getConfig().getBoolean("hooks.discordsrv", false)) {
+            this.hookManager.getHook(HookType.DiscordSRV).onEnable();
+        }
 
         final VanishPlugin self = this;
 

--- a/src/main/java/org/kitteh/vanish/VanishPlugin.java
+++ b/src/main/java/org/kitteh/vanish/VanishPlugin.java
@@ -40,8 +40,8 @@ import java.util.HashSet;
 
 public final class VanishPlugin extends JavaPlugin {
     private final HashSet<String> haveInventoriesOpen = new HashSet<>();
-    private VanishManager manager;
     private final HookManager hookManager = new HookManager(this);
+    private VanishManager manager;
 
     /**
      * Informs VNP that a user has closed their fake chest
@@ -146,6 +146,22 @@ public final class VanishPlugin extends JavaPlugin {
     }
 
     /**
+     * Calls hooks for when player has sent a fake join message
+     * Internal use only please.
+     *
+     * @param player the fake joining player
+     */
+    public void hooksFakeJoin(@NonNull Player player) { this.hookManager.onFakeJoin(player); }
+
+    /**
+     * Calls hooks for when player has sent a fake quit message
+     * Internal use only please.
+     *
+     * @param player the fake quitting player
+     */
+    public void hooksFakeQuit(@NonNull Player player) { this.hookManager.onFakeQuit(player); }
+
+    /**
      * Sends a message to all players with vanish.statusupdates permission
      *
      * @param message the message to send
@@ -158,7 +174,7 @@ public final class VanishPlugin extends JavaPlugin {
      * Sends a message to all players with vanish.statusupdates but one
      *
      * @param message the message to send
-     * @param avoid player to not send the message to
+     * @param avoid   player to not send the message to
      */
     public void messageStatusUpdate(@NonNull String message, @Nullable Player avoid) {
         for (final Player player : this.getServer().getOnlinePlayers()) {

--- a/src/main/java/org/kitteh/vanish/hooks/Hook.java
+++ b/src/main/java/org/kitteh/vanish/hooks/Hook.java
@@ -51,4 +51,12 @@ public abstract class Hook {
     public void onVanish(@NonNull Player player) {
 
     }
+
+    public void onFakeJoin(@NonNull Player player) {
+
+    }
+
+    public void onFakeQuit(@NonNull Player player) {
+
+    }
 }

--- a/src/main/java/org/kitteh/vanish/hooks/HookManager.java
+++ b/src/main/java/org/kitteh/vanish/hooks/HookManager.java
@@ -137,6 +137,18 @@ public final class HookManager {
         }
     }
 
+    public void onFakeJoin(@NonNull Player player) {
+        for(final Hook hook : this.hooks.values()) {
+            hook.onFakeJoin(player);
+        }
+    }
+
+    public void onFakeQuit(@NonNull Player player) {
+        for(final Hook hook : this.hooks.values()) {
+            hook.onFakeQuit(player);
+        }
+    }
+
     /**
      * Registers and initializes a hook
      *

--- a/src/main/java/org/kitteh/vanish/hooks/HookManager.java
+++ b/src/main/java/org/kitteh/vanish/hooks/HookManager.java
@@ -22,6 +22,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.kitteh.vanish.Debuggle;
 import org.kitteh.vanish.VanishPlugin;
+import org.kitteh.vanish.hooks.plugins.DiscordSRVHook;
 import org.kitteh.vanish.hooks.plugins.DynmapHook;
 import org.kitteh.vanish.hooks.plugins.EssentialsHook;
 import org.kitteh.vanish.hooks.plugins.VaultHook;
@@ -35,7 +36,8 @@ public final class HookManager {
     public enum HookType {
         Dynmap(DynmapHook.class),
         Essentials(EssentialsHook.class),
-        Vault(VaultHook.class);
+        Vault(VaultHook.class),
+        DiscordSRV(DiscordSRVHook.class);
 
         private final Class<? extends Hook> clazz;
 

--- a/src/main/java/org/kitteh/vanish/hooks/plugins/DiscordSRVHook.java
+++ b/src/main/java/org/kitteh/vanish/hooks/plugins/DiscordSRVHook.java
@@ -1,0 +1,62 @@
+/*
+ * VanishNoPacket
+ * Copyright (C) 2011-2021 Matt Baxter
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.kitteh.vanish.hooks.plugins;
+
+import github.scarsz.discordsrv.DiscordSRV;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.kitteh.vanish.VanishPlugin;
+import org.kitteh.vanish.hooks.Hook;
+
+public class DiscordSRVHook extends Hook {
+    private boolean enabled = false;
+    private DiscordSRV discordsrv;
+
+    public DiscordSRVHook(@NonNull VanishPlugin plugin) {
+        super(plugin);
+    }
+
+    @Override
+    public void onEnable() {
+        this.enabled = true;
+        final Plugin grab = this.plugin.getServer().getPluginManager().getPlugin("DiscordSRV");
+        if (grab != null) {
+            this.discordsrv = ((DiscordSRV) grab);
+            this.plugin.getLogger().info("Now hooking into DiscordSRV");
+        } else {
+            this.plugin.getLogger().info("You wanted DiscordSRV support. I could not find DiscordSRV.");
+            this.discordsrv = null;
+            this.enabled = false;
+        }
+    }
+
+    @Override
+    public void onFakeJoin(@NonNull Player player) {
+        if (this.enabled && player.hasPermission("vanish.hooks.discordsrv.broadcastfakejoin")) {
+            this.discordsrv.sendJoinMessage(player, "");
+        }
+    }
+
+    @Override
+    public void onFakeQuit(@NonNull Player player) {
+        if (this.enabled && player.hasPermission("vanish.hooks.discordsrv.broadcastfakequit")) {
+            this.discordsrv.sendLeaveMessage(player, "");
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -23,4 +23,4 @@ effects:
 permtest: false
 debug: false
 configVersionDoNotTouch: 
-    SeriouslyThisWillEraseYourConfig: 6
+    SeriouslyThisWillEraseYourConfig: 8

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -13,6 +13,7 @@ fakeannounce:
 hooks:
     essentials: false
     dynmap: false
+    discordsrv: false
 permissionsupdates:
     checkonworldchange: false
 effects:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: VanishNoPacket
 main: org.kitteh.vanish.VanishPlugin
 version: '${vnp-version}'
 website: https://kitteh.org
-softdepend: [Essentials,dynmap,PlaceholderAPI,Vault]
+softdepend: [Essentials,dynmap,PlaceholderAPI,Vault,DiscordSRV]
 author: mbaxter
 description: Vanish for the distinguished admin
 dev-url: https://dev.bukkit.org/projects/vanish

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -153,6 +153,12 @@ permissions:
   vanish.hooks.essentials.hide:
     default: false
     description: Hide user in Essentials
+  vanish.hooks.discordsrv.broadcastfakejoin:
+    default: false
+    description: Broadcast fake join messages to DiscordSRV
+  vanish.hooks.discordsrv.broadcastfakequit:
+    default: false
+    description: Broadcast fake quit messages to DiscordSRV
   vanish.spout.status:
     default: false
     description: See a status bar if vanished in spoutcraft

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -243,6 +243,8 @@ permissions:
       vanish.toggle.all: true
       vanish.hooks.dynmap.alwayshidden: true
       vanish.hooks.essentials.hide: true
+      vanish.hooks.discordsrv.broadcastfakejoin: true
+      vanish.hooks.discordsrv.broadcastfakequit: true
       vanish.permtest.all: true
       vanish.spout.status: true
       vanish.reload: true


### PR DESCRIPTION
This adds a hook into DiscordSRV which will allow VanishNoPacket to:
 - Broadcast fake join messages to Discord.
 - Broadcast fake quit messages to Discord.

It will also add the following things to facilitate this:
 - `hooks.discordsrv` config option (config version has been bumped to 8 and old configs will be updated).
 - `vanish.hooks.discordsrv.broadcastfakejoin` and `vanish.hooks.discordsrv.broadcastfakequit` permissions.
 - Hook methods that trigger whenever someone fake joins/quits (`onFakeJoin` and `onFakeQuit`).

I have tried to extensively test and follow the current format, but if something isn't quite right I can be contacted either here or on Discord (Dinty#4988).

It should also be noted that the latest stable build of DiscordSRV does not cancel leave messages of players who are vanished with VanishNoPacket, however this has been fixed in the development build.

