### PR TITLE
Delay removing players from the vanished players set by one tick

### DIFF
--- a/src/main/java/org/kitteh/vanish/VanishManager.java
+++ b/src/main/java/org/kitteh/vanish/VanishManager.java
@@ -18,6 +18,7 @@
 package org.kitteh.vanish;
 
 import com.google.common.collect.ImmutableSet;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Effect;
 import org.bukkit.Location;
@@ -174,10 +175,12 @@ public final class VanishManager {
      * @param player the player who has quit
      */
     public void playerQuit(@NonNull Player player) {
-        Debuggle.log("Quitting: " + player.getName());
+        String name = player.getName();
+        Debuggle.log("Quitting: " + name);
         this.resetSleepingIgnored(player);
         VanishPerms.userQuit(player);
-        this.removeVanished(player.getName());
+        // Run one tick later so plugins listening on higher priorities can still retrieve their vanish state.
+        Bukkit.getScheduler().runTaskLater(plugin, () -> this.removeVanished(player.getName()), 1L);
     }
 
     /**


### PR DESCRIPTION
When plugins are listening to the `PlayerQuitEvent` at a higher than NORMAL priority, they cannot retrieve if the player was vanished before they left. This simply delays removing the player from the set by one tick to avoid this issue.