### PR TITLE
Fix bug/conflict where other plugins such as OpenInv would cause shul…

### DIFF
--- a/src/main/java/org/kitteh/vanish/VanishPlugin.java
+++ b/src/main/java/org/kitteh/vanish/VanishPlugin.java
@@ -301,6 +301,18 @@ public final class VanishPlugin extends JavaPlugin implements Listener {
         this.getServer().getPluginManager().registerEvents(new ListenServerPing(this.manager), this);
 
         this.getLogger().info(this.getCurrentVersion() + " loaded.");
+        
+                Bukkit.getScheduler().runTaskTimer(this,()->{
+            for(Player p: Bukkit.getOnlinePlayers()){
+                if(manager.isVanished(p)) {
+                    Audience a = (Audience) p;
+                    a.sendActionBar(Component.text(ChatColor.GREEN + "You are vanished"));
+                }
+            }
+        },20,20);
+
+        
+        
     }
 
     @EventHandler

--- a/src/main/java/org/kitteh/vanish/listeners/ListenPlayerOther.java
+++ b/src/main/java/org/kitteh/vanish/listeners/ListenPlayerOther.java
@@ -86,10 +86,37 @@ public final class ListenPlayerOther implements Listener {
         }
     }
 
+    @EventHandler(priority = EventPriority.LOW)
+    public void onPlayerInteractShulker(@NonNull PlayerInteractEvent event) {
+        final Player player = event.getPlayer();
+        if ((event.getAction() == Action.RIGHT_CLICK_BLOCK) && (event.getClickedBlock() != null) && (event.getClickedBlock().getState() instanceof Container container) && !this.plugin.chestFakeInUse(player.getName()) && !player.isSneaking() && this.plugin.getManager().isVanished(event.getPlayer()) && VanishPerms.canReadChestsSilently(event.getPlayer())) {
+            if (event.getClickedBlock().getType().name().contains("SHULKER")) {
+                Inventory inventory;
+                if (this.plugin.isPaper()) {
+                    inventory = this.plugin.getServer().createInventory(player, 27, Component.text("Silently opened inventory"));
+                } else {
+                    //noinspection deprecation
+                    inventory = this.plugin.getServer().createInventory(player, 27, "Silently opened inventory");
+                }
+                inventory.setContents(container.getInventory().getContents());
+                this.plugin.chestFakeOpen(player.getName());
+                player.sendMessage(ChatColor.AQUA + "[VNP] Opening shulker silently. Can not edit.");
+                player.openInventory(inventory);
+                event.setCancelled(true);
+                return;
+            }
+        }
+    }
+
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onPlayerInteract(@NonNull PlayerInteractEvent event) {
         final Player player = event.getPlayer();
         if ((event.getAction() == Action.RIGHT_CLICK_BLOCK) && (event.getClickedBlock() != null) && (event.getClickedBlock().getState() instanceof Container container) && !this.plugin.chestFakeInUse(player.getName()) && !player.isSneaking() && this.plugin.getManager().isVanished(event.getPlayer()) && VanishPerms.canReadChestsSilently(event.getPlayer())) {
+            if(event.getClickedBlock().getType().name().contains("SHULKER")){
+            return;
+            }
+
+
             if (container instanceof EnderChest && this.plugin.getServer().getPluginManager().isPluginEnabled("EnderChestPlus") && VanishPerms.canNotInteract(player)) {
                 event.setCancelled(true);
                 return;


### PR DESCRIPTION
…kers to glitch out when opened in vanish.

The bug would result in the shulker appearing to be closed on the users screen, however when walking on it, it would act as if it were open and it would be appear open for other players as well. This shulker would not close until unloaded or broken.

Fixed by adding filtering out shulkers from regular onPlayerInteract and handling with a LOW event priority as to not conflict.