### PR TITLE
Cancel sculk detection events

### DIFF
--- a/src/main/java/org/kitteh/vanish/listeners/ListenEntity.java
+++ b/src/main/java/org/kitteh/vanish/listeners/ListenEntity.java
@@ -22,6 +22,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockReceiveGameEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityTargetEvent;
@@ -83,6 +84,17 @@ public final class ListenEntity implements Listener {
     public void onVehicleEntityCollision(@NonNull VehicleEntityCollisionEvent event) {
         if ((event.getEntity() instanceof Player player) && this.plugin.getManager().isVanished(player)) {
             event.setCancelled(true);
+        }
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onBlockReceiveGameEvent(@NonNull BlockReceiveGameEvent event) {
+        if (event.getEntity() instanceof Player) {
+            Player player = (Player) event.getEntity();
+
+            if (this.plugin.getManager().isVanished(player)) {
+                event.setCancelled(true);
+            }
         }
     }
 }

--- a/src/main/java/org/kitteh/vanish/listeners/ListenEntity.java
+++ b/src/main/java/org/kitteh/vanish/listeners/ListenEntity.java
@@ -89,8 +89,7 @@ public final class ListenEntity implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onBlockReceiveGameEvent(@NonNull BlockReceiveGameEvent event) {
-        if (event.getEntity() instanceof Player) {
-            Player player = (Player) event.getEntity();
+        if (event.getEntity() instanceof Player player) {
 
             if (this.plugin.getManager().isVanished(player)) {
                 event.setCancelled(true);

--- a/src/main/java/org/kitteh/vanish/listeners/ListenEntity.java
+++ b/src/main/java/org/kitteh/vanish/listeners/ListenEntity.java
@@ -90,7 +90,6 @@ public final class ListenEntity implements Listener {
     @EventHandler(ignoreCancelled = true)
     public void onBlockReceiveGameEvent(@NonNull BlockReceiveGameEvent event) {
         if (event.getEntity() instanceof Player player) {
-
             if (this.plugin.getManager().isVanished(player)) {
                 event.setCancelled(true);
             }


### PR DESCRIPTION
I've patched this so that vanished players can't trigger sculk sensors unless they actually stand on top of them.

Docs for the event: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/event/block/BlockReceiveGameEvent.html