### PR TITLE
Modernise fakeannounce messages

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -8,8 +8,8 @@
 #
 fakeannounce:
     automaticforsilentjoin: false
-    join: '%p joined the game.'
-    quit: '%p left the game.'
+    join: '%p joined the game'
+    quit: '%p left the game'
 hooks:
     essentials: false
     dynmap: false


### PR DESCRIPTION
It seems that the period was removed at some point so I have updated the config to match modern minecraft versions.

```
  "multiplayer.player.joined": "%s joined the game",
  "multiplayer.player.left": "%s left the game",
```